### PR TITLE
SVCPLAN-2374: install xfsdump

### DIFF
--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -10,3 +10,4 @@ profile_acctd::required_pkgs:
   - "perl-DBD-mysql"
   - "perl-MailTools"
   - "perl-LWP-Protocol-https"
+  - "xfsdump"  # for temporary backup solution (long-term, see SVCPLAN-1610)


### PR DESCRIPTION
Install xfsdump for temporary backup solution.

Tested on hli-sched (which runs acctd for HOLL-I).